### PR TITLE
Add light theme toggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -15,9 +15,27 @@
     --card-hover-border: rgba(0, 204, 255, 0.5); /* 悬停边框颜色 */
 }
 
+/* 浅色主题变量 */
+.light-theme {
+    --primary-color: #0066ff;
+    --primary-light: #4da3ff;
+    --secondary-color: #f5f5f5;
+    --accent-color: #ff4081;
+    --text-color: #222222;
+    --text-muted: #555555;
+    --border-color: rgba(0,0,0,0.1);
+    --page-gradient-start: #f5f5f5;
+    --page-gradient-end: #e5e5e5;
+    --card-gradient-start: #ffffff;
+    --card-gradient-end: #f2f2f2;
+    --card-accent: rgba(0,102,255,0.1);
+    --card-hover-border: rgba(0,102,255,0.4);
+}
+
 .page-bg {
     background: linear-gradient(180deg, var(--page-gradient-start), var(--page-gradient-end));
     min-height: 100vh;
+    color: var(--text-color);
     /* 柔和赛博点状背景 */
     background-image: 
         linear-gradient(180deg, var(--page-gradient-start), var(--page-gradient-end)),

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="page-bg text-white">
+<body class="page-bg">
     <!-- 将历史记录按钮移到左上角 -->
     <div class="fixed top-4 left-4 z-50">
         <button onclick="toggleHistory(event)" class="bg-[#222] hover:bg-[#333] border border-[#333] hover:border-white rounded-lg px-4 py-2 transition-colors" aria-label="观看历史">
@@ -50,6 +50,11 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
             </svg>
+        </button>
+    </div>
+    <div class="fixed top-4 right-16 z-50">
+        <button id="themeToggleBtn" onclick="toggleTheme()" class="bg-[#222] hover:bg-[#333] border border-[#333] hover:border-white rounded-lg px-4 py-2 transition-colors" aria-label="切换主题">
+            <span id="themeIcon" class="block w-6 h-6 text-center">☀️</span>
         </button>
     </div>
     

--- a/js/ui.js
+++ b/js/ui.js
@@ -10,6 +10,27 @@ function toggleSettings(e) {
 const toastQueue = [];
 let isShowingToast = false;
 
+// 主题切换相关
+function applyTheme(theme) {
+    document.documentElement.classList.toggle('light-theme', theme === 'light');
+    const icon = document.getElementById('themeIcon');
+    if (icon) icon.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+function toggleTheme() {
+    const current = document.documentElement.classList.contains('light-theme') ? 'light' : 'dark';
+    const next = current === 'light' ? 'dark' : 'light';
+    localStorage.setItem('theme', next);
+    applyTheme(next);
+}
+
+function initTheme() {
+    const saved = localStorage.getItem('theme') || 'dark';
+    applyTheme(saved);
+}
+
+document.addEventListener('DOMContentLoaded', initTheme);
+
 function showToast(message, type = 'error') {
     // 将新的toast添加到队列
     toastQueue.push({ message, type });

--- a/player.html
+++ b/player.html
@@ -12,8 +12,8 @@
             padding: 0;
             width: 100%;
             height: 100%;
-            background-color: #0f1622;
-            color: white;
+            background-color: var(--page-gradient-start);
+            color: var(--text-color);
         }
         .player-container {
             width: 100%;
@@ -155,6 +155,9 @@
         <a href="index.html" class="px-4 py-2 bg-[#222] hover:bg-[#333] border border-[#333] rounded-lg transition-colors">
             返回首页
         </a>
+        <button id="themeToggleBtn" onclick="toggleTheme()" class="ml-2 px-4 py-2 bg-[#222] hover:bg-[#333] border border-[#333] rounded-lg transition-colors" aria-label="切换主题">
+            <span id="themeIcon" class="block w-5 h-5 text-center">☀️</span>
+        </button>
     </header>
 
     <main class="container mx-auto px-4 py-4">
@@ -232,6 +235,7 @@
     <script src="https://s4.zstatic.net/ajax/libs/hls.js/1.5.6/hls.min.js" integrity="sha256-X1GmLMzVcTBRiGjEau+gxGpjRK96atNczcLBg5w6hKA=" crossorigin="anonymous"></script>
     <script src="https://s4.zstatic.net/ajax/libs/dplayer/1.26.0/DPlayer.min.js" integrity="sha256-OJg03lDZP0NAcl3waC9OT5jEa8XZ8SM2n081Ik953o4=" crossorigin="anonymous"></script>
     <script src="js/config.js"></script>
+    <script src="js/ui.js"></script>
     <script>
         // 全局变量
         let currentVideoTitle = '';


### PR DESCRIPTION
## Summary
- add theme toggle button on homepage and player
- support light mode via CSS variables
- implement theme switching logic in `js/ui.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683cf4ca024c832f8fe2069d36199b52